### PR TITLE
Improve Dolibarr configure role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
 # Ansible Collection - l00ptr.dolibarr
 
 ## Description
-This collection provides roles to :
- - Install
- - Configure
- - Upgrade 
- - Sync
+This collection provides a few roles to manage your Dolibarr instances.
 
-Your Dolibarr instances. 
-
+Currently we provide those roles :
+ - [Install](docs/role_install.md)
+ - [Configure](docs/role_configure.md)
+ - [Upgrade](docs/role_upgrade.md) 
+ - [Sync](docs/role_sync.md)
 
 We try to keep variable name consistent between the roles composing this collection.
 
-This collection is currently only available for Debian 9 and 10.
+This collection is currently only tested on Debian 9 and 10.
 
 ## Tested with Ansible
 

--- a/docs/role_configure.md
+++ b/docs/role_configure.md
@@ -1,0 +1,46 @@
+# Ansible role dolibarr install
+
+An Ansible role dedicated to configure Dolibarr installed on Debian 9 an 10. 
+
+The idea behind this role is to run the steps required to build a running 
+instance of Dolibarr after installing the source code.
+
+## Role Variables
+
+    dolibarr_version: 12.0
+
+Version of Dolibarr we want to install on our managed remote host.
+
+    dolibarr_http_rootdir: /var/www/
+
+Root directory where we will store our Dolibarr instance. Our role will create
+a directory based on the dolibarr_domain under this dolibarr_http_rootdir. So 
+by default we create the /var/www/dolibarr.example.com directory and use it to
+store our Dolibarr instance.
+
+    dolibarr_domain: dolibarr.example.com
+
+FQDN under which we will use this Dolibarr instance.
+
+    dolibarr_http_user: www-data
+
+Unix/Linux owning the Dolibarr instance directory (should probably equal to the
+user running your webserver or php-fpm process).
+
+    dolibarr_http_group: www-data
+
+Unix/Linux group for the Dolibarr instance directory (should probably equal to 
+the "group running" your webserver or php-fpm process).
+
+## Dependencies
+This role is part of a collection to install and manage your Dolibarr instance,
+this collection **doesn't** install and configure :
+  - The web  servers
+  - The database servers
+  - PHP
+
+If you want to fully automate your Dolibarr install you must write / find some 
+specific roles for those components.
+
+You also probably need to install and configure a git client on the managed
+host (required to clone the Dolibarr code from github).

--- a/roles/configure/defaults/main.yml
+++ b/roles/configure/defaults/main.yml
@@ -1,2 +1,16 @@
 ---
 # defaults file for configure
+dolibarr_http_user: www-data
+dolibarr_http_group: www-data
+dolibarr_http_rootdir: /var/www/
+dolibarr_domain: dolibarr.example.com
+dolibarr_http_proto: http
+dolibarr_main_document_root: "{{ dolibarr_http_rootdir }}{{ dolibarr_domain }}"
+dolibarr_main_data_root: "{{ dolibarr_http_rootdir }}{{ dolibarr_domain}}_documents"
+dolibarr_main_db_type: mysqli
+dolibarr_main_db_host: localhost
+dolibarr_main_db_port: 3306
+dolibarr_main_db_name: dolibarr
+dolibarr_main_db_user: dolibarr
+dolibarr_main_db_pass: dolibarr
+dolibarr_main_extra_config: ""

--- a/roles/configure/tasks/main.yml
+++ b/roles/configure/tasks/main.yml
@@ -1,6 +1,36 @@
 ---
 # tasks file for configure
 - name: Template configuration file
-  template:
+  ansible.builtin.template:
     src: conf.php.jinja2
-    dest: "{{ dolibarr_main_document_root }}/conf/conf.php"
+    dest: "{{ dolibarr_http_rootdir }}/{{ dolibarr_domain }}/conf/conf.php"
+
+- name: Run step1.php to init the database
+  ansible.builtin.command:
+    cmd: |
+      php step1.php set fr {{ dolibarr_main_document_root }}
+      {{ dolibarr_main_data_root }}
+      {{ dolibarr_http_proto }}://{{ dolibarr_domain }}
+      root root
+      {{ dolibarr_main_db_type }} {{ dolibarr_main_db_host }}
+      {{ dolibarr_main_db_name }} {{ dolibarr_main_db_user }} 
+      {{ dolibarr_main_db_pass }} {{ dolibarr_main_db_port }} llx_
+    chdir: "{{ dolibarr_http_rootdir }}/{{ dolibarr_domain }}/install/"
+    creates: "{{ dolibarr_main_data_root }}/install.lock"
+  become: yes
+  become_user: "{{ dolibarr_http_user }}"
+
+- name: Run step2.php to init the database
+  ansible.builtin.command:
+    cmd: php step2.php set
+    chdir: "{{ dolibarr_http_rootdir }}/{{ dolibarr_domain }}/install/"
+    creates: "{{ dolibarr_main_data_root }}/install.lock"
+  become: yes
+  become_user: "{{ dolibarr_http_user }}"
+      
+- name: Lock install and upgrade process
+  ansible.builtin.file:
+    path: "{{ dolibarr_main_data_root }}/install.lock"
+    state: touch
+    owner: root
+    group: root

--- a/roles/configure/templates/conf.php.jinja2
+++ b/roles/configure/templates/conf.php.jinja2
@@ -1,21 +1,31 @@
 <?php
 
-$dolibarr_main_url_root='{{ dolibarr_http_proto}}://{{ dolibarr_main_url_root }}';
+$dolibarr_main_url_root='{{ dolibarr_http_proto }}://{{ dolibarr_domain }}';
 $dolibarr_main_document_root='{{ dolibarr_main_document_root }}';
 $dolibarr_main_data_root='{{ dolibarr_main_data_root }}';
-$dolibarr_main_db_host='{{ dolibarr_main_db_host|default('localhost') }}';
-$dolibarr_main_db_port='{{ dolibarr_main_db_port|default('3306') }}';
-$dolibarr_main_db_name='{{ dolibarr_main_db_name|default('dolibarr') }}';
-$dolibarr_main_db_user='{{ dolibarr_main_db_user|default('dolibarr') }}';
-$dolibarr_main_db_pass='{{ dolibarr_main_db_pass|default('') }}';
-$dolibarr_main_db_type='{{ dolibarr_main_db_type|default('mysql')}}';
+$dolibarr_main_db_host='{{ dolibarr_main_db_host }}';
+$dolibarr_main_db_port='{{ dolibarr_main_db_port }}';
+$dolibarr_main_db_name='{{ dolibarr_main_db_name }}';
+$dolibarr_main_db_user='{{ dolibarr_main_db_user }}';
+$dolibarr_main_db_pass='{{ dolibarr_main_db_pass }}';
+$dolibarr_main_db_type='{{ dolibarr_main_db_type }}';
+
+{% if dolibarr_main_db_type == 'mysqli' %}
+
 $dolibarr_main_db_character_set='utf8';
 $dolibarr_main_db_collation='utf8_unicode_ci';
+$dolibarr_main_restrict_os_commands='mysqldump, mysql';
+
+{% elif dolibarr_main_db_type == 'pgsql' %}
+
+$dolibarr_main_restrict_os_commands='pg_dump, pgrestore';
+
+{% endif %}
+
 $dolibarr_main_instance_unique_id='84b5bc91f83b56e458db71e0adac2b62';
 $dolibarr_main_authentication='dolibarr';
 $dolibarr_main_force_https='0';
 $dolibarr_main_prod='0';
-$dolibarr_main_restrict_os_commands='mysqldump, mysql, pg_dump, pgrestore';
 $dolibarr_main_restrict_ip='';
 $dolibarr_nocsrfcheck='0';
 


### PR DESCRIPTION
- Allow to create specific config file for mariadb or postgresql
- Run step1 and step2 script after configuring Dolibarr
- Add some basic documentation about the configure role
- Create install.lock after configuring our Dolibarr