### PR TITLE
Add conditionnal tasks to install PHP RDBMS package

### DIFF
--- a/roles/install/defaults/main.yml
+++ b/roles/install/defaults/main.yml
@@ -6,3 +6,4 @@ dolibarr_domain: dolibarr.example.com
 dolibarr_http_user: www-data
 dolibarr_http_group: www-data
 dolibarr_http_proto: https
+dolibarr_main_db_type: mysqli

--- a/roles/install/tasks/install_packages_debian.yml
+++ b/roles/install/tasks/install_packages_debian.yml
@@ -1,5 +1,5 @@
 ---
-- name:
+- name: Install PHP common packages
   apt:
     state: present
     name:
@@ -14,3 +14,17 @@
       - php-cli
       - php-zip
       - php-curl
+
+- name: Install PHP pgsql package
+  apt:
+    state: present
+    name:
+      - php-pgsql
+  when: dolibarr_main_db_type == 'pgsql'
+
+- name: Install PHP pgsql package
+  apt:
+    state: present
+    name:
+      - php-mysql
+  when: dolibarr_main_db_type == 'mysqli'


### PR DESCRIPTION
Allow to install php-psqgl or php-mysql depending of the target RDBMS