### PR TITLE
Add slash at the end of all path

### DIFF
--- a/roles/configure/defaults/main.yml
+++ b/roles/configure/defaults/main.yml
@@ -5,8 +5,8 @@ dolibarr_http_group: www-data
 dolibarr_http_rootdir: /var/www/
 dolibarr_domain: dolibarr.example.com
 dolibarr_http_proto: http
-dolibarr_main_document_root: "{{ dolibarr_http_rootdir }}{{ dolibarr_domain }}"
-dolibarr_main_data_root: "{{ dolibarr_http_rootdir }}{{ dolibarr_domain}}_documents"
+dolibarr_main_document_root: "{{ dolibarr_http_rootdir }}{{ dolibarr_domain }}/"
+dolibarr_main_data_root: "{{ dolibarr_http_rootdir }}{{ dolibarr_domain}}_documents/"
 dolibarr_main_db_type: mysqli
 dolibarr_main_db_host: localhost
 dolibarr_main_db_port: 3306


### PR DESCRIPTION
Path should always finish by slash. That's easier when templating or
contactainin them (building new path)