### PR TITLE
Add customisable class name to module

### DIFF
--- a/roles/install_modules/tasks/install_module.yml
+++ b/roles/install_modules/tasks/install_module.yml
@@ -18,6 +18,6 @@
 - name: install_module | Activate/deactivate module
   ansible.builtin.command:
     cmd: '{{ dolibarr_module_control_script }} --data_root={{ dolibarr_main_document_root }}
-      --module=mod{{ item.name | capitalize }} --action={{ activation_action }}'
+      --module={{ item.class | default("mod" + item.name | capitalize) }} --action={{ activation_action }}'
   changed_when: ((manage_module.stdout | from_json).changed_modules | int) != 0
   register: manage_module


### PR DESCRIPTION
In some cases, the module class name cannot be derived from the module name.
(e.g. module: bankimportapi class: modBankImportApi)

fix #6 